### PR TITLE
capistrano-tagging breaks with bundler >= 1.1rc

### DIFF
--- a/lib/capistrano/tagging.rb
+++ b/lib/capistrano/tagging.rb
@@ -4,7 +4,7 @@ end
 
 require 'capistrano'
 
-Capistrano::Configuration.instance.load do
+Capistrano::Configuration.instance(:must_exist).load do
 
   after  "deploy:restart", "tagging:deploy"
   before "deploy:cleanup", "tagging:cleanup"


### PR DESCRIPTION
```
$ bundle exec rails c
/home/mbarnash/.rvm/gems/ree-1.8.7-2011.03@domgeo/gems/capistrano-tagging-  0.0.8/lib/capistrano/tagging.rb:7:in `load': wrong number of arguments (0 for 1) (ArgumentError)
from /home/mbarnash/.rvm/gems/ree-1.8.7-2011.03@domgeo/gems/capistrano-tagging-0.0.8/lib/capistrano/tagging.rb:7
from /home/mbarnash/.rvm/gems/ree-1.8.7-2011.03@domgeo/gems/bundler-1.1.rc/lib/bundler/runtime.rb:76:in `require'
from /home/mbarnash/.rvm/gems/ree-1.8.7-2011.03@domgeo/gems/bundler-1.1.rc/lib/bundler/runtime.rb:76:in `require'
from /home/mbarnash/.rvm/gems/ree-1.8.7-2011.03@domgeo/gems/bundler-1.1.rc/lib/bundler/runtime.rb:55:in `each'
from /home/mbarnash/.rvm/gems/ree-1.8.7-2011.03@domgeo/gems/bundler-1.1.rc/lib/bundler/runtime.rb:55:in `require'
from /home/mbarnash/.rvm/gems/ree-1.8.7-2011.03@domgeo/gems/bundler-1.1.rc/lib/bundler.rb:128:in `require'
from /home/mbarnash/work/domgeo/config/application.rb:5
from /home/mbarnash/.rvm/gems/ree-1.8.7-2011.03@domgeo/gems/railties-3.0.11/lib/rails/commands.rb:21:in `require'
from /home/mbarnash/.rvm/gems/ree-1.8.7-2011.03@domgeo/gems/railties-3.0.11/lib/rails/commands.rb:21
from script/rails:6:in `require'
from script/rails:6
```

I'm not sure what's the main cause of this, maybe it's somehow connected with changes in bundler's load mechanisms. Anyway, we'd better ensure we have Capistrano config to work with.
